### PR TITLE
Fix for adding non-square matrices

### DIFF
--- a/nml.c
+++ b/nml.c
@@ -637,7 +637,7 @@ int nml_mat_add_r(nml_mat *m1, nml_mat *m2) {
   }
   int i, j;
   for(i = 0; i < m1->num_rows; i++) {
-    for(j = 0; j < m2->num_rows; j++) {
+    for(j = 0; j < m1->num_cols; j++) {
       m1->data[i][j] += m2->data[i][j];
     }
   }
@@ -660,7 +660,7 @@ int nml_mat_sub_r(nml_mat *m1, nml_mat *m2) {
   }
   int i, j;
   for(i = 0; i < m1->num_rows; i++) {
-    for(j = 0; j < m2->num_cols; j++) {
+    for(j = 0; j < m1->num_cols; j++) {
       m1->data[i][j] -= m2->data[i][j];
     }
   }


### PR DESCRIPTION
Fixed a typo where it was iterating over (m1->rows and then m2->rows) instead of (m1->rows and then m2->cols)

It doesn't matter when adding square matrices like in the add_matrices.c example but breaks with non-square matrices