### PR TITLE
🩳🧙 fix nml_mat_col_swap_r validation check

### DIFF
--- a/nml.c
+++ b/nml.c
@@ -506,7 +506,7 @@ nml_mat *nml_mat_col_swap(nml_mat *m, unsigned int col1, unsigned int col2) {
 }
 
 int nml_mat_col_swap_r(nml_mat *m, unsigned int col1, unsigned int col2) {
-  if (col1 >= m->num_cols || col2 >= m->num_rows) {
+  if (col1 >= m->num_cols || col2 >= m->num_cols) {
     NML_FERROR(CANNOT_SWAP_ROWS, col1, col2, m->num_cols);
     return 0;
   }


### PR DESCRIPTION
I changed the validation check inside the columns swap function. It was comparing _col2_ against the number of rows of the matrix, when i believe it should be comparing against the number of columns. 

P.S. Loved the tutorial you made about this library :)